### PR TITLE
Refactor frame styles (closes #153)

### DIFF
--- a/assets/stylesheets/base.css
+++ b/assets/stylesheets/base.css
@@ -249,9 +249,26 @@ button:-moz-focusring,
 /* Page */
 .page {
   position: relative;
-  padding: 4.5em;
+  padding: 3em;
   box-shadow: 0 10px 100px 0 rgba(34, 36, 38, 0.1);
   transition: box-shadow 0.2s linear;
+}
+.page[style^="border-color"] {
+  padding: 4.5em;
+}
+.page[style^="border-color"]:before {
+  content: " ";
+  display: block;
+  position: absolute;
+  left: 2em;
+  top: 2em;
+  right: 2em;
+  bottom: 2em;
+  border-color: inherit;
+  border-width: 1em;
+  border-style: solid;
+  pointer-events: none;
+  transition: border-color 0.2s ease-in-out;
 }
 @media only screen {
   .page:hover {
@@ -259,31 +276,12 @@ button:-moz-focusring,
   }
 }
 @media only screen and (max-width: 767px) {
-  .page {
+  .page,
+  .page[style^="border-color"] {
     padding: 0;
   }
-}
-
-/* Frame */
-.frame {
-  position: absolute;
-  left: 2em;
-  top: 2em;
-  right: 2em;
-  bottom: 2em;
-  border-color: midnightblue;
-  transition: border-color 0.2s ease-in-out;
-  border-width: 1em;
-  border-style: solid;
-  pointer-events: none;
-}
-@media only screen and (max-width: 767px) {
-  .frame {
-    opacity: 0;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+  .page[style^="border-color"]:before {
+    display: none;
   }
 }
 
@@ -303,9 +301,6 @@ button:-moz-focusring,
 .grid .grid {
   margin-left: -1em;
   margin-right: -1em;
-}
-.page .grid:first-child {
-  margin: -1.5em;
 }
 
 /* Rows */

--- a/index.html
+++ b/index.html
@@ -59,8 +59,7 @@
 		</div>
 	</div>
 	<div id="pages">
-		<div class="page">
-			<div class="frame"></div>
+		<div class="page" style="border-color: midnightblue;">
 			<div class="stackable grid">
 				<div class="row">
 					<div class="three wide center aligned column">
@@ -397,8 +396,8 @@
 		document.getElementById("lviv-rent-months").innerHTML = "paid " + monthsLivingInLviv + " month" + (monthsLivingInLviv === 1 ? "" : "s") + " of rent already";
 		function switchToColor(color) {
 			try {
-				document.querySelectorAll(".frame").forEach(function(frame) {
-					frame.style.borderColor = color;
+				document.querySelectorAll(".page").forEach(function(page) {
+					page.style.borderColor = color;
 				});
 				document.querySelectorAll(".avatar").forEach(function(avatar) {
 					avatar.contentDocument.getElementById("circle").setAttribute("fill", color)

--- a/posts/introduction-letter-to-binary-studio/assets/stylesheets/base.css
+++ b/posts/introduction-letter-to-binary-studio/assets/stylesheets/base.css
@@ -170,27 +170,27 @@ button:-moz-focusring,
 }
 
 /* Desktop */
-#desktop {
+#pages {
   max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }
 @media only screen and (min-width: 768px) and (max-width: 991px) {
-  #desktop {
+  #pages {
     width: 723px;
     margin-top: calc((100% - 723px) / 2);
     margin-bottom: calc((100% - 723px) / 2);
   }
 }
 @media only screen and (min-width: 992px) and (max-width: 1199px) {
-  #desktop {
+  #pages {
     width: 933px;
     margin-top: calc((100% - 933px) / 2);
     margin-bottom: calc((100% - 933px) / 2);
   }
 }
 @media only screen and (min-width: 1200px) {
-  #desktop {
+  #pages {
     width: 1127px;
     margin-top: calc((100% - 1127px) / 2);
     margin-bottom: calc((100% - 1127px) / 2);
@@ -200,23 +200,26 @@ button:-moz-focusring,
 /* Page */
 .page {
   position: relative;
-  padding: 4.5em;
+  padding: 3em;
   box-shadow: 0 10px 100px 0 rgba(34, 36, 38, 0.1);
   transition: box-shadow 0.2s linear;
-  margin-bottom: 1em;
 }
-.page:last-child {
-  margin-bottom: 0;
+.page[style^="border-color"] {
+  padding: 4.5em;
 }
-.page:hover {
-  box-shadow: 0 10px 100px 0 rgba(34, 36, 38, 0.3);
-}
-@media only screen and (max-width: 767px) {
-  .page {
-    padding: 0;
-    margin: 0;
-    box-shadow: none;
-  }
+.page[style^="border-color"]:before {
+  content: " ";
+  display: block;
+  position: absolute;
+  left: 2em;
+  top: 2em;
+  right: 2em;
+  bottom: 2em;
+  border-color: inherit;
+  border-width: 1em;
+  border-style: solid;
+  pointer-events: none;
+  transition: border-color 0.2s ease-in-out;
 }
 .page.photo {
   padding: 0;
@@ -225,27 +228,21 @@ button:-moz-focusring,
   width: 100%;
   display: block;
 }
-
-/* Frame */
-.frame {
-  position: absolute;
-  left: 2em;
-  top: 2em;
-  right: 2em;
-  bottom: 2em;
-  border-color: orange;
-  transition: border-color 0.2s ease-in-out;
-  border-width: 1em;
-  border-style: solid;
-  pointer-events: none;
+.page:not(:last-child) {
+  margin-bottom: 1em;
+}
+@media only screen {
+  .page:hover {
+    box-shadow: 0 10px 100px 0 rgba(34, 36, 38, 0.3);
+  }
 }
 @media only screen and (max-width: 767px) {
-  .frame {
-    opacity: 0;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+  .page,
+  .page[style^="border-color"] {
+    padding: 0;
+  }
+  .page[style^="border-color"]:before {
+    display: none;
   }
 }
 

--- a/posts/introduction-letter-to-binary-studio/index.html
+++ b/posts/introduction-letter-to-binary-studio/index.html
@@ -27,9 +27,8 @@
 	<link rel="stylesheet" href="./assets/stylesheets/base.css">
 </head>
 <body>
-	<div id="desktop">
-		<div class="page">
-			<div class="frame"></div>
+	<div id="pages">
+		<div class="page" style="border-color: orange;">
 			<div class="content">
 				<div class="avatar-wrapper">
 					<object class="avatar" data="../../assets/images/avatar-2012.svg" role="img" aria-label="My profile picture"></object>

--- a/ru-ru/index.html
+++ b/ru-ru/index.html
@@ -59,8 +59,7 @@
 		</div>
 	</div>
 	<div id="pages">
-		<div class="page">
-			<div class="frame"></div>
+		<div class="page" style="border-color: midnightblue;">
 			<div class="stackable grid">
 				<div class="row">
 					<div class="three wide center aligned column">
@@ -397,8 +396,8 @@
 		document.getElementById("lviv-rent-months").innerHTML = "уже заплатил за " + monthsLivingInLviv + " месяцев аренды";
 		function switchToColor(color) {
 			try {
-				document.querySelectorAll(".frame").forEach(function(frame) {
-					frame.style.borderColor = color;
+				document.querySelectorAll(".page").forEach(function(page) {
+					page.style.borderColor = color;
 				});
 				document.querySelectorAll(".avatar").forEach(function(avatar) {
 					avatar.contentDocument.getElementById("circle").setAttribute("fill", color)

--- a/sw.js
+++ b/sw.js
@@ -137,7 +137,7 @@ self.__precacheManifest = [
   },
   {
     "url": "assets/stylesheets/base.css",
-    "revision": "04981566cd9f1fc4aba08995a6df17e7"
+    "revision": "4dd8e3eb1987ad219044d314710c6675"
   },
   {
     "url": "favicon.ico",
@@ -145,7 +145,7 @@ self.__precacheManifest = [
   },
   {
     "url": "index.html",
-    "revision": "de1289d27b6e63ee5ee565e8c74b5eaa"
+    "revision": "de95576d9ba13abf74dcab614e8e9c0e"
   },
   {
     "url": "posts/index.html",
@@ -157,19 +157,19 @@ self.__precacheManifest = [
   },
   {
     "url": "posts/introduction-letter-to-binary-studio/assets/stylesheets/base.css",
-    "revision": "bb2c1b7ffc2ed684e0be22b2f024be92"
+    "revision": "f2b4617192b349f7eb2a99c9adf8a77d"
   },
   {
     "url": "posts/introduction-letter-to-binary-studio/index.html",
-    "revision": "77ff89d182f630488b9b33f1c1f76950"
+    "revision": "dff3a3c162478dee59e6b81b93492dbb"
   },
   {
     "url": "ru-ru/index.html",
-    "revision": "aebbea6280811c80e65fdb5bd9f9432b"
+    "revision": "a3b6c94f4c3394e268be16432bba8be9"
   },
   {
     "url": "uk-ua/index.html",
-    "revision": "5d3c49130856ce9854986c63bb5a1c51"
+    "revision": "4974874d3a5f218df5916b9b31c3942d"
   }
 ].concat(self.__precacheManifest || []);
 workbox.precaching.suppressWarnings();

--- a/uk-ua/index.html
+++ b/uk-ua/index.html
@@ -59,8 +59,7 @@
 		</div>
 	</div>
 	<div id="pages">
-		<div class="page">
-			<div class="frame"></div>
+		<div class="page" style="border-color: midnightblue;">
 			<div class="stackable grid">
 				<div class="row">
 					<div class="three wide center aligned column">
@@ -397,8 +396,8 @@
 		document.getElementById("lviv-rent-months").innerHTML = "вже заплатив за " + monthsLivingInLviv + " місяців оренди";
 		function switchToColor(color) {
 			try {
-				document.querySelectorAll(".frame").forEach(function(frame) {
-					frame.style.borderColor = color;
+				document.querySelectorAll(".page").forEach(function(page) {
+					page.style.borderColor = color;
 				});
 				document.querySelectorAll(".avatar").forEach(function(avatar) {
 					avatar.contentDocument.getElementById("circle").setAttribute("fill", color)


### PR DESCRIPTION
`.page` block will draw the frame of red color if `style="border-color: red;"` is present. Color can be changed, obviously (with JavaScript as well). This imposes some limitations too — there's no way to have a _standard_ border on page, but given that it tries to mimic the real-world piece of paper there should be no need to have one. If user absolutely needs to have a border it can be simulated with `box-shadow`.